### PR TITLE
Fix line drawing beyond candles

### DIFF
--- a/SMC Hybrid
+++ b/SMC Hybrid
@@ -634,7 +634,9 @@ if  ta.crossover(close , Major_HighLevel) and  LockBreak_M != Major_HighIndex
         LockBreak_M := Major_HighIndex
         ExternalTrend := 'Up Trend'
         if MajorBuBoSLine_Show == 'On'
-            MajorLine_BoSBull     := line.new(Major_HighIndex, Major_HighLevel , bar_index , Major_HighLevel , style = MajorBuBoSLine_Style , color = MajorBuBoSLine_Color)
+            if not na(MajorLine_BoSBull)
+                line.delete(MajorLine_BoSBull)
+            MajorLine_BoSBull     := line.new(Major_HighIndex, Major_HighLevel , bar_index , Major_HighLevel , xloc = xloc.bar_index , extend = extend.none , style = MajorBuBoSLine_Style , color = MajorBuBoSLine_Color)
             MajorLabel_BoSBull    := label.new((Major_HighIndex + bar_index) / 2 , Major_HighLevel   ,
              text = 'Bos' , color = color.rgb(0,0,0,100), textcolor = MajorBuBoSLine_Color ,size = size.normal )
     else if ExternalTrend == 'Down Trend' 
@@ -644,7 +646,9 @@ if  ta.crossover(close , Major_HighLevel) and  LockBreak_M != Major_HighIndex
         LockBreak_M := Major_HighIndex
         ExternalTrend := 'Up Trend'
         if MajorBuChoChLine_Show == 'On'
-            MajorLine_ChoChBull    := line.new(Major_HighIndex, Major_HighLevel , bar_index , Major_HighLevel , style = MajorBuChoChLine_Style , color = MajorBuChoChLine_Color)
+            if not na(MajorLine_ChoChBull)
+                line.delete(MajorLine_ChoChBull)
+            MajorLine_ChoChBull    := line.new(Major_HighIndex, Major_HighLevel , bar_index , Major_HighLevel , xloc = xloc.bar_index , extend = extend.none , style = MajorBuChoChLine_Style , color = MajorBuChoChLine_Color)
             MajorLabel_ChoChBull   := label.new((Major_HighIndex + bar_index) / 2 , Major_HighLevel   ,
              text = 'choch' , color = color.rgb(0,0,0,100), textcolor = MajorBuChoChLine_Color ,size = size.normal )
 else
@@ -658,10 +662,12 @@ if  ta.crossunder(close, Major_LowLevel) and  LockBreak_M!= Major_LowIndex
         LockBreak_M := Major_LowIndex
         ExternalTrend := 'Down Trend'
         if MajorBeBoSLine_Show == 'On'
-            MajorLine_BoSBear     := line.new(Major_LowIndex, Major_LowLevel , bar_index , Major_LowLevel , style = MajorBeBoSLine_Style , color = MajorBeBoSLine_Color)
+            if not na(MajorLine_BoSBear)
+                line.delete(MajorLine_BoSBear)
+            MajorLine_BoSBear     := line.new(Major_LowIndex, Major_LowLevel , bar_index , Major_LowLevel , xloc = xloc.bar_index , extend = extend.none , style = MajorBeBoSLine_Style , color = MajorBeBoSLine_Color)
             MajorLabel_BoSBear    := label.new((Major_LowIndex + bar_index) / 2 , Major_LowLevel   ,
              text = 'Bos' , color = color.rgb(0,0,0,100),
-             textcolor = MajorBeBoSLine_Color , style = label.style_label_up ,size = size.normal)        
+             textcolor = MajorBeBoSLine_Color , style = label.style_label_up ,size = size.normal)
     else if ExternalTrend == 'Up Trend' 
         Bearish_Major_ChoCh := true
         ChoCh_MajorType.push('Bear Major ChoCh')
@@ -669,7 +675,9 @@ if  ta.crossunder(close, Major_LowLevel) and  LockBreak_M!= Major_LowIndex
         LockBreak_M := Major_LowIndex
         ExternalTrend := 'Down Trend'
         if MajorBeChoChLine_Show == 'On'
-            MajorLine_ChoChBear    := line.new(Major_LowIndex, Major_LowLevel , bar_index , Major_LowLevel , style = MajorBeChoChLine_Style , color = MajorBeChoChLine_Color)
+            if not na(MajorLine_ChoChBear)
+                line.delete(MajorLine_ChoChBear)
+            MajorLine_ChoChBear    := line.new(Major_LowIndex, Major_LowLevel , bar_index , Major_LowLevel , xloc = xloc.bar_index , extend = extend.none , style = MajorBeChoChLine_Style , color = MajorBeChoChLine_Color)
             MajorLabel_ChoChBear   := label.new((Major_LowIndex + bar_index) / 2 , Major_LowLevel   ,
              text = 'choch' , color = color.rgb(0,0,0,100), textcolor = MajorBeChoChLine_Color, style = label.style_label_up ,size = size.normal)
 else 
@@ -682,8 +690,10 @@ if  Minor_HighLevel < close  and  LockBreak_m != Minor_HighIndex
         BoS_MinorIndex.push(bar_index)
         LockBreak_m := Minor_HighIndex
         InternalTrend := 'Up Trend'
-        if MinorBuBoSLine_Show  == 'On' 
-            MinorLine_BoSBull     := line.new(Minor_HighIndex, Minor_HighLevel , bar_index , Minor_HighLevel , style = MinorBuBoSLine_Style , color = MinorBuBoSLine_Color)
+        if MinorBuBoSLine_Show  == 'On'
+            if not na(MinorLine_BoSBull)
+                line.delete(MinorLine_BoSBull)
+            MinorLine_BoSBull     := line.new(Minor_HighIndex, Minor_HighLevel , bar_index , Minor_HighLevel , xloc = xloc.bar_index , extend = extend.none , style = MinorBuBoSLine_Style , color = MinorBuBoSLine_Color)
             MinorLabel_BoSBull    := label.new((Minor_HighIndex + bar_index) / 2 , Minor_HighLevel   , text = '$$$' , color = color.rgb(0,0,0,100), textcolor = MinorBuBoSLine_Color ,size = size.small )
     else if InternalTrend == 'Down Trend' 
         Bullish_Minor_ChoCh := true
@@ -691,8 +701,10 @@ if  Minor_HighLevel < close  and  LockBreak_m != Minor_HighIndex
         ChoCh_MinorIndex.push(bar_index)
         LockBreak_m := Minor_HighIndex
         InternalTrend := 'Up Trend'
-        if MinorBuChoChLine_Show  == 'On'         
-            MinorLine_ChoChBull    := line.new(Minor_HighIndex, Minor_HighLevel , bar_index , Minor_HighLevel , style = MinorBuChoChLine_Style , color = MinorBuChoChLine_Color)
+        if MinorBuChoChLine_Show  == 'On'
+            if not na(MinorLine_ChoChBull)
+                line.delete(MinorLine_ChoChBull)
+            MinorLine_ChoChBull    := line.new(Minor_HighIndex, Minor_HighLevel , bar_index , Minor_HighLevel , xloc = xloc.bar_index , extend = extend.none , style = MinorBuChoChLine_Style , color = MinorBuChoChLine_Color)
             MinorLabel_ChoChBull   := label.new((Minor_HighIndex + bar_index) / 2 , Minor_HighLevel   , text = '$$$' , color = color.rgb(0,0,0,100), textcolor = MinorBuChoChLine_Color ,size = size.small )
 else 
     Bullish_Minor_ChoCh := false
@@ -704,18 +716,22 @@ if  Minor_LowLevel > close and  LockBreak_m!= Minor_LowIndex
         BoS_MinorIndex.push(bar_index)
         LockBreak_m := Minor_LowIndex
         InternalTrend := 'Down Trend'
-        if MinorBeBoSLine_Show  == 'On' 
-            MinorLine_BoSBear     := line.new(Minor_LowIndex, Minor_LowLevel , bar_index , Minor_LowLevel , style = MinorBeBoSLine_Style , color = MinorBeBoSLine_Color)
+        if MinorBeBoSLine_Show  == 'On'
+            if not na(MinorLine_BoSBear)
+                line.delete(MinorLine_BoSBear)
+            MinorLine_BoSBear     := line.new(Minor_LowIndex, Minor_LowLevel , bar_index , Minor_LowLevel , xloc = xloc.bar_index , extend = extend.none , style = MinorBeBoSLine_Style , color = MinorBeBoSLine_Color)
             MinorLabel_BoSBear    := label.new((Minor_LowIndex + bar_index) / 2 , Minor_LowLevel   , text = '$$$' , color = color.rgb(0,0,0,100),
-             textcolor = MinorBeBoSLine_Color , style = label.style_label_up ,size = size.small) 
+             textcolor = MinorBeBoSLine_Color , style = label.style_label_up ,size = size.small)
     else if InternalTrend == 'Up Trend' 
         Bearish_Minor_ChoCh := true
         ChoCh_MinorType.push('Bear Minor ChoCh')
         ChoCh_MinorIndex.push(bar_index)
         LockBreak_m := Minor_LowIndex
         InternalTrend := 'Down Trend'
-        if MinorBeChoChLine_Show  == 'On' 
-            MinorLine_ChoChBear    := line.new(Minor_LowIndex, Minor_LowLevel , bar_index , Minor_LowLevel , style = MinorBeChoChLine_Style , color = MinorBeChoChLine_Color)
+        if MinorBeChoChLine_Show  == 'On'
+            if not na(MinorLine_ChoChBear)
+                line.delete(MinorLine_ChoChBear)
+            MinorLine_ChoChBear    := line.new(Minor_LowIndex, Minor_LowLevel , bar_index , Minor_LowLevel , xloc = xloc.bar_index , extend = extend.none , style = MinorBeChoChLine_Style , color = MinorBeChoChLine_Color)
             MinorLabel_ChoChBear   := label.new((Minor_LowIndex + bar_index) / 2 , Minor_LowLevel   , text = '$$$' , color = color.rgb(0,0,0,100),
              textcolor = MinorBeChoChLine_Color, style = label.style_label_up ,size = size.small)
 else


### PR DESCRIPTION
## Summary
- clean up line drawing logic in *SMC Hybrid* indicator to prevent lines extending past candle bodies
- ensure old lines are removed before drawing new ones

## Testing
- `grep -n "line.new" -n 'SMC Hybrid'`


------
https://chatgpt.com/codex/tasks/task_e_684af1777f608325bcfe3dd1edd74e10