### PR TITLE
Combine minor BOS and ChoCh colors

### DIFF
--- a/SMC Hybrid
+++ b/SMC Hybrid
@@ -8,13 +8,14 @@ MajorBoSLine_Style      = line.style_solid
 MajorBoSLine_Color      = input.color(#0000FF, "สี Major BOS", group="BOS/ChoCh")
 MinorBoSLine_Show       = 'On'
 MinorBoSLine_Style      = line.style_dashed
-MinorBoSLine_Color      = input.color(color.black, "สี Minor BOS", group="BOS/ChoCh")
+MinorLine_Color         = input.color(color.black, "สี Minor BOS/ChoCh", group="BOS/ChoCh")
+MinorBoSLine_Color      = MinorLine_Color
 MajorChoChLine_Show     = 'On'
 MajorChoChLine_Style    = line.style_solid
 MajorChoChLine_Color    = input.color(#ff0000, "สี Major ChoCh", group="BOS/ChoCh")
 MinorChoChLine_Show     = 'On'
 MinorChoChLine_Style    = line.style_dashed
-MinorChoChLine_Color    = input.color(color.black, "สี Minor ChoCh", group="BOS/ChoCh")
+MinorChoChLine_Color    = MinorLine_Color
 // === Variable Initialization ===
 Open = open
 High = high


### PR DESCRIPTION
## Summary
- combine Minor BOS and Minor ChoCh color inputs into a single setting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68538426cf8c8325943622ecc83d308a