### PR TITLE
Fix minor line overlay

### DIFF
--- a/SMC Hybrid
+++ b/SMC Hybrid
@@ -672,7 +672,7 @@ if  Minor_HighLevel < close  and  LockBreak_m != Minor_HighIndex
         LockBreak_m := Minor_HighIndex
         InternalTrend := 'Up Trend'
         if MinorBoSLine_Show  == 'On' 
-            MinorLine_BoSBull     := line.new(Minor_HighIndex, Minor_HighLevel , bar_index , Minor_HighLevel , style = MinorBoSLine_Style , color = MinorBoSLine_Color, extend = extend.none)
+            MinorLine_BoSBull     := line.new(Minor_HighIndex + 1, Minor_HighLevel , bar_index - 1 , Minor_HighLevel , style = MinorBoSLine_Style , color = MinorBoSLine_Color, extend = extend.none)
             MinorLabel_BoSBull    := label.new((Minor_HighIndex + bar_index) / 2 , Minor_HighLevel   , text = '$$$' , color = color.rgb(0,0,0,100), textcolor = MinorBoSLine_Color ,size = size.small )
     else if InternalTrend == 'Down Trend' 
         Bullish_Minor_ChoCh := true
@@ -681,7 +681,7 @@ if  Minor_HighLevel < close  and  LockBreak_m != Minor_HighIndex
         LockBreak_m := Minor_HighIndex
         InternalTrend := 'Up Trend'
         if MinorChoChLine_Show  == 'On'         
-            MinorLine_ChoChBull    := line.new(Minor_HighIndex, Minor_HighLevel , bar_index , Minor_HighLevel , style = MinorChoChLine_Style , color = MinorChoChLine_Color, extend = extend.none)
+            MinorLine_ChoChBull    := line.new(Minor_HighIndex + 1, Minor_HighLevel , bar_index - 1 , Minor_HighLevel , style = MinorChoChLine_Style , color = MinorChoChLine_Color, extend = extend.none)
             MinorLabel_ChoChBull   := label.new((Minor_HighIndex + bar_index) / 2 , Minor_HighLevel   , text = '$$$' , color = color.rgb(0,0,0,100), textcolor = MinorChoChLine_Color ,size = size.small )
 else 
     Bullish_Minor_ChoCh := false
@@ -694,7 +694,7 @@ if  Minor_LowLevel > close and  LockBreak_m!= Minor_LowIndex
         LockBreak_m := Minor_LowIndex
         InternalTrend := 'Down Trend'
         if MinorBoSLine_Show  == 'On' 
-            MinorLine_BoSBear     := line.new(Minor_LowIndex, Minor_LowLevel , bar_index , Minor_LowLevel , style = MinorBoSLine_Style , color = MinorBoSLine_Color, extend = extend.none)
+            MinorLine_BoSBear     := line.new(Minor_LowIndex + 1, Minor_LowLevel , bar_index - 1 , Minor_LowLevel , style = MinorBoSLine_Style , color = MinorBoSLine_Color, extend = extend.none)
             MinorLabel_BoSBear    := label.new((Minor_LowIndex + bar_index) / 2 , Minor_LowLevel   , text = '$$$' , color = color.rgb(0,0,0,100),
              textcolor = MinorBoSLine_Color , style = label.style_label_up ,size = size.small) 
     else if InternalTrend == 'Up Trend' 
@@ -704,7 +704,7 @@ if  Minor_LowLevel > close and  LockBreak_m!= Minor_LowIndex
         LockBreak_m := Minor_LowIndex
         InternalTrend := 'Down Trend'
         if MinorChoChLine_Show  == 'On' 
-            MinorLine_ChoChBear    := line.new(Minor_LowIndex, Minor_LowLevel , bar_index , Minor_LowLevel , style = MinorChoChLine_Style , color = MinorChoChLine_Color, extend = extend.none)
+            MinorLine_ChoChBear    := line.new(Minor_LowIndex + 1, Minor_LowLevel , bar_index - 1 , Minor_LowLevel , style = MinorChoChLine_Style , color = MinorChoChLine_Color, extend = extend.none)
             MinorLabel_ChoChBear   := label.new((Minor_LowIndex + bar_index) / 2 , Minor_LowLevel   , text = '$$$' , color = color.rgb(0,0,0,100),
              textcolor = MinorChoChLine_Color, style = label.style_label_up ,size = size.small)
 else


### PR DESCRIPTION
## Summary
- adjust minor BOS/ChoCH lines to start after pivot and end before breakout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68539b67250083259db48ce716169516