### PR TITLE
Add Order Block Boxes script

### DIFF
--- a/OrderBlockBoxes.pine
+++ b/OrderBlockBoxes.pine
@@ -1,0 +1,69 @@
+//@version=5 
+indicator("Order Block Boxes", overlay=true)
+
+// === INPUTS ===
+showOrderblock = input.bool(true, "Show Order Blocks")
+colorBull      = input.color(#0066ff26,  "Bullish OB Color")
+colorBear      = input.color(color.rgb(255, 82, 82, 85),  "Bearish OB Color")
+maxBoxes       = input.int(6, "Max Boxes")
+
+// === ARRAYS ===
+var box[] bullBoxes = array.new_box()
+var box[] bearBoxes = array.new_box()
+
+// === DETECT & DRAW ORDER BLOCKS ===
+if showOrderblock
+    // ── Bullish Order Block (Demand) ──
+    if low > high[2]
+        box ob = na
+        if low[1] > high[3]
+            ob := box.new(left = bar_index[2], top = high[2], right = bar_index, bottom = low[1], bgcolor = colorBull, border_color = colorBull)
+        else if low[2] <= low[1]
+            ob := box.new(left = bar_index[2], top = high[2], right = bar_index, bottom = low[2], bgcolor = colorBull, border_color = colorBull)
+        else
+            ob := box.new(left = bar_index[2], top = high[2], right = bar_index, bottom = low[1], bgcolor = colorBull, border_color = colorBull)
+        array.push(bullBoxes, ob)
+        if array.size(bullBoxes) > maxBoxes
+            oldbx = array.shift(bullBoxes)
+            box.delete(oldbx)
+
+    // ── Bearish Order Block (Supply) ──
+    if high < low[2]
+        box ob = na
+        if high[1] < low[3]
+            ob := box.new(left = bar_index[2], top = low[2], right = bar_index, bottom = high[1], bgcolor = colorBear, border_color = colorBear)
+        else if high[2] <= high[1]
+            ob := box.new(left = bar_index[2], top = low[2], right = bar_index, bottom = high[1], bgcolor = colorBear, border_color = colorBear)
+        else
+            ob := box.new(left = bar_index[2], top = low[2], right = bar_index, bottom = high[2], bgcolor = colorBear, border_color = colorBear)
+        array.push(bearBoxes, ob)
+        if array.size(bearBoxes) > maxBoxes
+            oldbx = array.shift(bearBoxes)
+            box.delete(oldbx)
+
+// === EXTEND BOXES TO CURRENT BAR ===
+if array.size(bullBoxes) > 0
+    for i = 0 to array.size(bullBoxes) - 1
+        bx = array.get(bullBoxes, i)
+        box.set_right(bx, bar_index)
+
+if array.size(bearBoxes) > 0
+    for i = 0 to array.size(bearBoxes) - 1
+        bx = array.get(bearBoxes, i)
+        box.set_right(bx, bar_index)
+
+// === DELETE BOXES WHEN BOS (Break of Structure) TOUCH ===
+if array.size(bullBoxes) > 0
+    for i = array.size(bullBoxes) - 1 to 0
+        bx = array.get(bullBoxes, i)
+        if low <= box.get_top(bx)
+            box.delete(bx)
+            array.remove(bullBoxes, i)
+
+if array.size(bearBoxes) > 0
+    for i = array.size(bearBoxes) - 1 to 0
+        bx = array.get(bearBoxes, i)
+        if high >= box.get_top(bx)  // touched top of Supply OB
+            box.delete(bx)
+            array.remove(bearBoxes, i)
+


### PR DESCRIPTION
## Summary
- add Pine Script for identifying order blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b25f28e08325b9bd7a952af3d34c