### PR TITLE
Unify zone labels

### DIFF
--- a/SMC Hybrid
+++ b/SMC Hybrid
@@ -522,15 +522,15 @@ if showOrderblock
         box ob = na
         if low[1] > high[3]
             ob := box.new(left = bar_index[2], top = high[2], right = bar_index, bottom = low[1], bgcolor = colorBull, border_color = color.new(colorBull, 100))
-            box.set_text(ob, "Dz")
+            box.set_text(ob, "OB")
             box.set_text_halign(ob, text.align_right)
         else if low[2] <= low[1]
             ob := box.new(left = bar_index[2], top = high[2], right = bar_index, bottom = low[2], bgcolor = colorBull, border_color = color.new(colorBull, 100))
-            box.set_text(ob, "Dz")
+            box.set_text(ob, "OB")
             box.set_text_halign(ob, text.align_right)
         else
             ob := box.new(left = bar_index[2], top = high[2], right = bar_index, bottom = low[1], bgcolor = colorBull, border_color = color.new(colorBull, 100))
-            box.set_text(ob, "Dz")
+            box.set_text(ob, "OB")
             box.set_text_halign(ob, text.align_right)
         array.push(bullBoxes, ob)
         if array.size(bullBoxes) > maxBoxes
@@ -542,15 +542,15 @@ if showOrderblock
         box ob = na
         if high[1] < low[3]
             ob := box.new(left = bar_index[2], top = low[2], right = bar_index, bottom = high[1], bgcolor = colorBear, border_color = color.new(colorBear, 100))
-            box.set_text(ob, "Sz")
+            box.set_text(ob, "OB")
             box.set_text_halign(ob, text.align_right)
         else if high[2] <= high[1]
             ob := box.new(left = bar_index[2], top = low[2], right = bar_index, bottom = high[1], bgcolor = colorBear, border_color = color.new(colorBear, 100))
-            box.set_text(ob, "Sz")
+            box.set_text(ob, "OB")
             box.set_text_halign(ob, text.align_right)
         else
             ob := box.new(left = bar_index[2], top = low[2], right = bar_index, bottom = high[2], bgcolor = colorBear, border_color = color.new(colorBear, 100))
-            box.set_text(ob, "Sz")
+            box.set_text(ob, "OB")
             box.set_text_halign(ob, text.align_right)
         array.push(bearBoxes, ob)
         if array.size(bearBoxes) > maxBoxes


### PR DESCRIPTION
## Summary
- rename all supply/demand box labels to `OB` for consistency

## Testing
- `grep -n "OB" -n 'SMC Hybrid'`

------
https://chatgpt.com/codex/tasks/task_e_6853b6f29ec883258b19cc6de3482a31