### PR TITLE
Fix order block text size

### DIFF
--- a/SMC Hybrid
+++ b/SMC Hybrid
@@ -524,14 +524,17 @@ if showOrderblock
             ob := box.new(left = bar_index[2], top = high[2], right = bar_index, bottom = low[1], bgcolor = colorBull, border_color = color.new(colorBull, 100))
             box.set_text(ob, "Dz")
             box.set_text_halign(ob, text.align_right)
+            box.set_text_size(ob, size.small)
         else if low[2] <= low[1]
             ob := box.new(left = bar_index[2], top = high[2], right = bar_index, bottom = low[2], bgcolor = colorBull, border_color = color.new(colorBull, 100))
             box.set_text(ob, "Dz")
             box.set_text_halign(ob, text.align_right)
+            box.set_text_size(ob, size.small)
         else
             ob := box.new(left = bar_index[2], top = high[2], right = bar_index, bottom = low[1], bgcolor = colorBull, border_color = color.new(colorBull, 100))
             box.set_text(ob, "Dz")
             box.set_text_halign(ob, text.align_right)
+            box.set_text_size(ob, size.small)
         array.push(bullBoxes, ob)
         if array.size(bullBoxes) > maxBoxes
             oldbx = array.shift(bullBoxes)
@@ -544,14 +547,17 @@ if showOrderblock
             ob := box.new(left = bar_index[2], top = low[2], right = bar_index, bottom = high[1], bgcolor = colorBear, border_color = color.new(colorBear, 100))
             box.set_text(ob, "Sz")
             box.set_text_halign(ob, text.align_right)
+            box.set_text_size(ob, size.small)
         else if high[2] <= high[1]
             ob := box.new(left = bar_index[2], top = low[2], right = bar_index, bottom = high[1], bgcolor = colorBear, border_color = color.new(colorBear, 100))
             box.set_text(ob, "Sz")
             box.set_text_halign(ob, text.align_right)
+            box.set_text_size(ob, size.small)
         else
             ob := box.new(left = bar_index[2], top = low[2], right = bar_index, bottom = high[2], bgcolor = colorBear, border_color = color.new(colorBear, 100))
             box.set_text(ob, "Sz")
             box.set_text_halign(ob, text.align_right)
+            box.set_text_size(ob, size.small)
         array.push(bearBoxes, ob)
         if array.size(bearBoxes) > maxBoxes
             oldbx = array.shift(bearBoxes)


### PR DESCRIPTION
## Summary
- add missing size parameter so "Sz" and "Dz" annotations use the same text size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853b78a4ca883259b8d03b6bbbd7354