### PR TITLE
Extend BOS/CHOCH lines

### DIFF
--- a/SMC Hybrid
+++ b/SMC Hybrid
@@ -432,7 +432,7 @@ if  ta.crossover(close , majorHighLevel) and  lockBreakM != majorHighIndex
         lockBreakM := majorHighIndex
         externalTrend := 'Up Trend'
         if majorBoSLineShow == 'On'
-            f_drawLineLabel(majorHighIndex, majorHighLevel, majorBoSLineStyle, majorBoSLineColor, 'Bos', label.style_label_down, size.normal)
+            f_drawLineLabel(majorHighIndex, majorHighLevel, majorBoSLineStyle, majorBoSLineColor, 'Bos', label.style_label_down, size.normal, extend.right)
     else if externalTrend == 'Down Trend' 
         bullishMajorChoCh := true
         chochMajorType.push('Bull Major ChoCh')
@@ -440,7 +440,7 @@ if  ta.crossover(close , majorHighLevel) and  lockBreakM != majorHighIndex
         lockBreakM := majorHighIndex
         externalTrend := 'Up Trend'
         if majorChoChLineShow == 'On'
-            f_drawLineLabel(majorHighIndex, majorHighLevel, majorChoChLineStyle, majorChoChLineColor, 'choch', label.style_label_down, size.normal)
+            f_drawLineLabel(majorHighIndex, majorHighLevel, majorChoChLineStyle, majorChoChLineColor, 'choch', label.style_label_down, size.normal, extend.right)
 else
     bullishMajorChoCh := false
     bullishMajorBoS   := false 
@@ -452,7 +452,7 @@ if  ta.crossunder(close, majorLowLevel) and  lockBreakM!= majorLowIndex
         lockBreakM := majorLowIndex
         externalTrend := 'Down Trend'
         if majorBoSLineShow == 'On'
-            f_drawLineLabel(majorLowIndex, majorLowLevel, majorBoSLineStyle, majorBoSLineColor, 'Bos', label.style_label_up, size.normal)
+            f_drawLineLabel(majorLowIndex, majorLowLevel, majorBoSLineStyle, majorBoSLineColor, 'Bos', label.style_label_up, size.normal, extend.right)
     else if externalTrend == 'Up Trend' 
         bearishMajorChoCh := true
         chochMajorType.push('Bear Major ChoCh')
@@ -460,7 +460,7 @@ if  ta.crossunder(close, majorLowLevel) and  lockBreakM!= majorLowIndex
         lockBreakM := majorLowIndex
         externalTrend := 'Down Trend'
         if majorChoChLineShow == 'On'
-            f_drawLineLabel(majorLowIndex, majorLowLevel, majorChoChLineStyle, majorChoChLineColor, 'choch', label.style_label_up, size.normal)
+            f_drawLineLabel(majorLowIndex, majorLowLevel, majorChoChLineStyle, majorChoChLineColor, 'choch', label.style_label_up, size.normal, extend.right)
 else 
     bearishMajorChoCh := false 
     bearishMajorBoS   := false 
@@ -472,7 +472,7 @@ if  minorHighLevel < close  and  lockBreakm != minorHighIndex
         lockBreakm := minorHighIndex
         internalTrend := 'Up Trend'
         if minorBoSLineShow  == 'On' and showDollarLabel
-            f_drawLineLabel(minorHighIndex, minorHighLevel, minorBoSLineStyle, minorBoSLineColor, '$$$', label.style_label_down, size.small, extend.none)
+            f_drawLineLabel(minorHighIndex, minorHighLevel, minorBoSLineStyle, minorBoSLineColor, '$$$', label.style_label_down, size.small, extend.right)
     else if internalTrend == 'Down Trend' 
         bullishMinorChoCh := true
         chochMinorType.push('Bull Minor ChoCh')
@@ -480,7 +480,7 @@ if  minorHighLevel < close  and  lockBreakm != minorHighIndex
         lockBreakm := minorHighIndex
         internalTrend := 'Up Trend'
         if minorChoChLineShow  == 'On' and showDollarLabel
-            f_drawLineLabel(minorHighIndex, minorHighLevel, minorChoChLineStyle, minorChoChLineColor, '$$$', label.style_label_down, size.small, extend.none)
+            f_drawLineLabel(minorHighIndex, minorHighLevel, minorChoChLineStyle, minorChoChLineColor, '$$$', label.style_label_down, size.small, extend.right)
 else 
     bullishMinorChoCh := false
     bullishMinorBoS   := false
@@ -492,7 +492,7 @@ if  minorLowLevel > close and  lockBreakm!= minorLowIndex
         lockBreakm := minorLowIndex
         internalTrend := 'Down Trend'
         if minorBoSLineShow  == 'On' and showDollarLabel
-            f_drawLineLabel(minorLowIndex, minorLowLevel, minorBoSLineStyle, minorBoSLineColor, '$$$', label.style_label_up, size.small, extend.none)
+            f_drawLineLabel(minorLowIndex, minorLowLevel, minorBoSLineStyle, minorBoSLineColor, '$$$', label.style_label_up, size.small, extend.right)
     else if internalTrend == 'Up Trend' 
         bearishMinorChoCh := true
         chochMinorType.push('Bear Minor ChoCh')
@@ -500,7 +500,7 @@ if  minorLowLevel > close and  lockBreakm!= minorLowIndex
         lockBreakm := minorLowIndex
         internalTrend := 'Down Trend'
         if minorChoChLineShow  == 'On' and showDollarLabel
-            f_drawLineLabel(minorLowIndex, minorLowLevel, minorChoChLineStyle, minorChoChLineColor, '$$$', label.style_label_up, size.small, extend.none)
+            f_drawLineLabel(minorLowIndex, minorLowLevel, minorChoChLineStyle, minorChoChLineColor, '$$$', label.style_label_up, size.small, extend.right)
 else
     bearishMinorChoCh := false
     bearishMinorBoS   := false


### PR DESCRIPTION
## Summary
- show previous BOS/CHOCH levels by extending lines to the right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853c645a02c8325ba6840811ef90934