### PR TITLE
Fix line style input

### DIFF
--- a/SMC Hybrid
+++ b/SMC Hybrid
@@ -19,7 +19,8 @@ minorChoChLineColor    = minorLineColor
 showDollarLabel       = input.bool(true, "liquidity", group="BOS/ChoCh")
 potentialGroup        = "Potential Levels"
 showPotential         = input.bool(true, "Show Potential BOS/ChoCh", group=potentialGroup)
-potentialStyle        = input.line_style(line.style_dotted, "Line Style", group=potentialGroup)
+potentialStyleInput   = input.string("Dotted", "Line Style", options=["Solid", "Dashed", "Dotted"], group=potentialGroup)
+potentialStyle        = potentialStyleInput == "Solid" ? line.style_solid : potentialStyleInput == "Dashed" ? line.style_dashed : line.style_dotted
 potentialColor        = input.color(color.gray, "Line Color", group=potentialGroup)
 // === Variable Initialization ===
 Open = open


### PR DESCRIPTION
## Summary
- use string input for line style to avoid missing function errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853c905b8e48325be8ddac447ac032f