### PR TITLE
Update BOS/ChoCh lines with wick crossing

### DIFF
--- a/SMC Hybrid
+++ b/SMC Hybrid
@@ -85,9 +85,9 @@ push_pivot(arrType, arrValue, arrIndex, valType, val, idx) =>
     array.push(arrValue, val)
     array.push(arrIndex, idx)
 
-f_drawLineLabel(idx, lvl, lstyle, lcolor, txt, labStyle, labSize, ext=extend.none) =>
-    line.new(idx, lvl, bar_index, lvl, style=lstyle, color=lcolor, extend=ext)
-    label.new((idx + bar_index) / 2, lvl, text=txt, color=color.rgb(0,0,0,100),
+f_drawLineLabel(idx, lvl, lstyle, lcolor, txt, labStyle, labSize, ext=extend.none, endLvl=lvl) =>
+    line.new(idx, lvl, bar_index, endLvl, style=lstyle, color=lcolor, extend=ext)
+    label.new((idx + bar_index) / 2, (lvl + endLvl) / 2, text=txt, color=color.rgb(0,0,0,100),
               textcolor=lcolor, style=labStyle, size=labSize)
 // === Pivot and Trend Logic ===
 if HighPivot  and  LowPivot
@@ -432,7 +432,7 @@ if  ta.crossover(high , majorHighLevel) and  lockBreakM != majorHighIndex
         lockBreakM := majorHighIndex
         externalTrend := 'Up Trend'
         if majorBoSLineShow == 'On'
-            f_drawLineLabel(majorHighIndex, majorHighLevel, majorBoSLineStyle, majorBoSLineColor, 'Bos', label.style_label_down, size.normal)
+            f_drawLineLabel(majorHighIndex, majorHighLevel, majorBoSLineStyle, majorBoSLineColor, 'Bos', label.style_label_down, size.normal, extend.none, high)
     else if externalTrend == 'Down Trend' 
         bullishMajorChoCh := true
         chochMajorType.push('Bull Major ChoCh')
@@ -440,7 +440,7 @@ if  ta.crossover(high , majorHighLevel) and  lockBreakM != majorHighIndex
         lockBreakM := majorHighIndex
         externalTrend := 'Up Trend'
         if majorChoChLineShow == 'On'
-            f_drawLineLabel(majorHighIndex, majorHighLevel, majorChoChLineStyle, majorChoChLineColor, 'choch', label.style_label_down, size.normal)
+            f_drawLineLabel(majorHighIndex, majorHighLevel, majorChoChLineStyle, majorChoChLineColor, 'choch', label.style_label_down, size.normal, extend.none, high)
 else
     bullishMajorChoCh := false
     bullishMajorBoS   := false 
@@ -452,7 +452,7 @@ if  ta.crossunder(low, majorLowLevel) and  lockBreakM!= majorLowIndex
         lockBreakM := majorLowIndex
         externalTrend := 'Down Trend'
         if majorBoSLineShow == 'On'
-            f_drawLineLabel(majorLowIndex, majorLowLevel, majorBoSLineStyle, majorBoSLineColor, 'Bos', label.style_label_up, size.normal)
+            f_drawLineLabel(majorLowIndex, majorLowLevel, majorBoSLineStyle, majorBoSLineColor, 'Bos', label.style_label_up, size.normal, extend.none, low)
     else if externalTrend == 'Up Trend' 
         bearishMajorChoCh := true
         chochMajorType.push('Bear Major ChoCh')
@@ -460,7 +460,7 @@ if  ta.crossunder(low, majorLowLevel) and  lockBreakM!= majorLowIndex
         lockBreakM := majorLowIndex
         externalTrend := 'Down Trend'
         if majorChoChLineShow == 'On'
-            f_drawLineLabel(majorLowIndex, majorLowLevel, majorChoChLineStyle, majorChoChLineColor, 'choch', label.style_label_up, size.normal)
+            f_drawLineLabel(majorLowIndex, majorLowLevel, majorChoChLineStyle, majorChoChLineColor, 'choch', label.style_label_up, size.normal, extend.none, low)
 else 
     bearishMajorChoCh := false 
     bearishMajorBoS   := false 
@@ -472,7 +472,7 @@ if  minorHighLevel < high  and  lockBreakm != minorHighIndex
         lockBreakm := minorHighIndex
         internalTrend := 'Up Trend'
         if minorBoSLineShow  == 'On' and showDollarLabel
-            f_drawLineLabel(minorHighIndex, minorHighLevel, minorBoSLineStyle, minorBoSLineColor, '$$$', label.style_label_down, size.small, extend.none)
+            f_drawLineLabel(minorHighIndex, minorHighLevel, minorBoSLineStyle, minorBoSLineColor, '$$$', label.style_label_down, size.small, extend.none, high)
     else if internalTrend == 'Down Trend' 
         bullishMinorChoCh := true
         chochMinorType.push('Bull Minor ChoCh')
@@ -480,7 +480,7 @@ if  minorHighLevel < high  and  lockBreakm != minorHighIndex
         lockBreakm := minorHighIndex
         internalTrend := 'Up Trend'
         if minorChoChLineShow  == 'On' and showDollarLabel
-            f_drawLineLabel(minorHighIndex, minorHighLevel, minorChoChLineStyle, minorChoChLineColor, '$$$', label.style_label_down, size.small, extend.none)
+            f_drawLineLabel(minorHighIndex, minorHighLevel, minorChoChLineStyle, minorChoChLineColor, '$$$', label.style_label_down, size.small, extend.none, high)
 else 
     bullishMinorChoCh := false
     bullishMinorBoS   := false
@@ -492,7 +492,7 @@ if  minorLowLevel > low and  lockBreakm!= minorLowIndex
         lockBreakm := minorLowIndex
         internalTrend := 'Down Trend'
         if minorBoSLineShow  == 'On' and showDollarLabel
-            f_drawLineLabel(minorLowIndex, minorLowLevel, minorBoSLineStyle, minorBoSLineColor, '$$$', label.style_label_up, size.small, extend.none)
+            f_drawLineLabel(minorLowIndex, minorLowLevel, minorBoSLineStyle, minorBoSLineColor, '$$$', label.style_label_up, size.small, extend.none, low)
     else if internalTrend == 'Up Trend' 
         bearishMinorChoCh := true
         chochMinorType.push('Bear Minor ChoCh')
@@ -500,7 +500,7 @@ if  minorLowLevel > low and  lockBreakm!= minorLowIndex
         lockBreakm := minorLowIndex
         internalTrend := 'Down Trend'
         if minorChoChLineShow  == 'On' and showDollarLabel
-            f_drawLineLabel(minorLowIndex, minorLowLevel, minorChoChLineStyle, minorChoChLineColor, '$$$', label.style_label_up, size.small, extend.none)
+            f_drawLineLabel(minorLowIndex, minorLowLevel, minorChoChLineStyle, minorChoChLineColor, '$$$', label.style_label_up, size.small, extend.none, low)
 else
     bearishMinorChoCh := false
     bearishMinorBoS   := false


### PR DESCRIPTION
## Summary
- adjust line drawing helper so BOS/ChoCh lines can end at breakout wick
- connect BOS/ChoCh lines to the breakout candle's high/low

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872448debf88325a3206d8779f9a694